### PR TITLE
fix using bash array syntax in sh file

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 set -e
 


### PR DESCRIPTION
[sh doesn't support arrays, like bash](https://unix.stackexchange.com/questions/140502/sh-how-to-use-array-in-sh-script-in-order-to-print-all-values-in-array)

fix #4 
